### PR TITLE
Messaging app crashes after a few MMS

### DIFF
--- a/src/com/android/messaging/ui/conversation/ConversationFragment.java
+++ b/src/com/android/messaging/ui/conversation/ConversationFragment.java
@@ -201,7 +201,8 @@ public class ConversationFragment extends Fragment implements ConversationDataLi
                     intent.getStringExtra(UIIntents.UI_INTENT_EXTRA_CONVERSATION_SELF_ID);
             Assert.notNull(conversationId);
             Assert.notNull(selfId);
-            if (TextUtils.equals(mBinding.getData().getConversationId(), conversationId)) {
+            if (isBound() && TextUtils
+                    .equals(mBinding.getData().getConversationId(), conversationId)) {
                 mComposeMessageView.updateConversationSelfIdOnExternalChange(selfId);
             }
         }


### PR DESCRIPTION
In some scenarios, data not bound when SIM state
change local broadcasts are received. See stacktrace
for more info. Protect against/skip call to update()
in such scenarios.

Bug-Id: CYNGNOS-3062, KIPPER-718

Change-Id: If94d789aecda47ebff775155c66b670a10ff7fe4